### PR TITLE
fix: missing label for Gas Station in sidebar (translate-fr)

### DIFF
--- a/fr/general.json
+++ b/fr/general.json
@@ -94,6 +94,7 @@
 		"palm_city_strefa_driftu":"Zone de Drift",
 
 		"lakeshore_city_garaz":"Planque",
+		"lakeshore_city_stacja_benzynowa":"Station-service",
 		"lakeshore_city_graffiti":"Street Art",
 		"lakeshore_city_niedzwiedz":"Ours",
 		"lakeshore_city_billboard":"Panneau",


### PR DESCRIPTION
This fix the label for "Gas Station" in the NFS Unbound map that was missing in french translation.